### PR TITLE
Add support for multiple/nested package.json files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "elltg-npm-script-run",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "elltg-npm-script-run",
-            "version": "1.0.7",
+            "version": "1.0.8",
             "devDependencies": {
                 "@types/glob": "^7.2.0",
                 "@types/mocha": "^9.1.1",
@@ -307,6 +307,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.38.0.tgz",
             "integrity": "sha512-/F63giJGLDr0ms1Cr8utDAxP2SPiglaD6V+pCOcG35P2jCqdfR7uuEhz1GIC3oy4hkUF8xA1XSXmd9hOh/a5EA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.38.0",
                 "@typescript-eslint/types": "5.38.0",
@@ -674,6 +675,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
             "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -716,6 +718,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -883,6 +886,7 @@
                     "url": "https://tidelift.com/funding/github/npm/browserslist"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001400",
                 "electron-to-chromium": "^1.4.251",
@@ -1260,6 +1264,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
             "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint/eslintrc": "^1.3.2",
                 "@humanwhocodes/config-array": "^0.10.4",
@@ -3227,6 +3232,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
             "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -3312,6 +3318,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
             "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^0.0.51",
@@ -3359,6 +3366,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
             "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.2.0",
@@ -3782,6 +3790,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.38.0.tgz",
             "integrity": "sha512-/F63giJGLDr0ms1Cr8utDAxP2SPiglaD6V+pCOcG35P2jCqdfR7uuEhz1GIC3oy4hkUF8xA1XSXmd9hOh/a5EA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@typescript-eslint/scope-manager": "5.38.0",
                 "@typescript-eslint/types": "5.38.0",
@@ -4059,7 +4068,8 @@
             "version": "8.8.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
             "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "acorn-import-assertions": {
             "version": "1.8.0",
@@ -4089,6 +4099,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -4210,6 +4221,7 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
             "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "caniuse-lite": "^1.0.30001400",
                 "electron-to-chromium": "^1.4.251",
@@ -4482,6 +4494,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
             "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@eslint/eslintrc": "^1.3.2",
                 "@humanwhocodes/config-array": "^0.10.4",
@@ -5925,7 +5938,8 @@
             "version": "4.8.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
             "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "unzipper": {
             "version": "0.10.11",
@@ -5985,6 +5999,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
             "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^0.0.51",
@@ -6017,6 +6032,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
             "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.2.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,10 +3,12 @@ import { readNpmScripts } from './read-npm-scripts';
 
 function openScriptInTerminal(
     terminal: vscode.Terminal | undefined,
-    selectedNpmScript: string
+    selectedNpmScript: string,
+    packageJsonPath: string
 ): void {
     if (terminal) {
         terminal.show();
+        terminal.sendText(`cd "${packageJsonPath}"`);
         terminal.sendText(`npm run ${selectedNpmScript}`);
     } else {
         vscode.window.showInformationMessage('No active terminal. Exiting...');
@@ -14,7 +16,19 @@ function openScriptInTerminal(
 }
 
 async function readNpmScriptsMain(openNewTerminal: boolean): Promise<void> {
-    const namedNpmScripts = await readNpmScripts();
+    const result = await readNpmScripts();
+
+    if (!result) {
+        vscode.window.showInformationMessage('No package.json selected or found. Exiting...');
+        return;
+    }
+
+    const { scripts: namedNpmScripts, packageJsonPath } = result;
+
+    if (namedNpmScripts.length === 0) {
+        vscode.window.showInformationMessage('No npm scripts found in package.json. Exiting...');
+        return;
+    }
 
     const selectedNpmScript = await vscode.window.showQuickPick(namedNpmScripts);
 
@@ -30,7 +44,7 @@ async function readNpmScriptsMain(openNewTerminal: boolean): Promise<void> {
         terminal = vscode.window.activeTerminal;
     }
 
-    openScriptInTerminal(terminal, selectedNpmScript);
+    openScriptInTerminal(terminal, selectedNpmScript, packageJsonPath);
 }
 
 export function activate(context: vscode.ExtensionContext) {


### PR DESCRIPTION
- Enhanced package.json discovery to search throughout workspace
- Added intelligent filtering to exclude node_modules, dist, build, out, and .git directories
- Implemented user selection when multiple package.json files are found
- Added automatic directory change before running npm scripts
- Improved error handling and user feedback
- Supports monorepo scenarios with multiple legitimate package.json files